### PR TITLE
Add travis build config files and upload artifacts into dist.apache.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+language: python
+python: 3.5
+sudo: required
+dist: trusty
+services: docker
+osx_image: xcode6.4
+
+env:
+  global:
+      - PYTHON_ARTIFACTS_DIR=python
+      - STAGING=https://dist.apache.org/repos/dist/dev/beam/${VERSION}/${PYTHON_ARTIFACTS_DIR}
+      - BEAM_SVN_DIR=https://dist.apache.org/repos/dist/dev/beam
+      - ZIP_FILE=apache-beam-${VERSION}.zip
+
+      - PLAT=x86_64
+      - BUILD_DEPENDS="Cython"
+      - TEST_DEPENDS=
+
+matrix:
+  exclude:
+    # Exclude the default Python 3.5 build
+    - python: 3.5
+  include:
+   - os: osx
+     language: generic
+     env:
+       - MB_PYTHON_VERSION=2.7
+   - os: linux
+     env:
+       - MB_PYTHON_VERSION=2.7
+   - os: linux
+     env:
+       - MB_PYTHON_VERSION=2.7
+       - UNICODE_WIDTH=16
+   - os: linux
+     env:
+       - MB_PYTHON_VERSION=2.7
+       - PLAT=i686
+   - os: linux
+     env:
+       - MB_PYTHON_VERSION=2.7
+       - PLAT=i686
+       - UNICODE_WIDTH=16
+
+before_install:
+    - source multibuild/common_utils.sh
+    - source multibuild/travis_steps.sh
+    - before_install
+
+install:
+    - wget $STAGING/$ZIP_FILE
+    - unzip $ZIP_FILE
+
+# VERSION and RC setup in travis build console > More options > Settings > Environment Variables with 'Display value in build log' enabled.
+script:
+    - build_wheel apache-beam-${VERSION} $PLAT
+
+after_success:
+    - ls -lh ${TRAVIS_BUILD_DIR}/wheelhouse/
+    - |
+      for artifact in ${TRAVIS_BUILD_DIR}/wheelhouse/*.*; do
+          mv $artifact ${artifact/$VERSION/$VERSION.$RC};
+      done
+    - source deploy_travis.sh
+    - deploy

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# Apache Beam Wheels
+
+## Overview
+
+`beam-wheels` is a helper repository of [apache beam](https://github.com/apache/beam), which helps a Release 
+Manager build python wheels on Linux/MacOS in a release process.
+
+## Structure
+
+There are 2 major parts in this repository.
+* [multibuild](https://github.com/matthew-brett/multibuild) as git submodule, helps build python wheels based on different os.
+
+* [travis](https://travis-ci.com/) configuration files, setups environment variables and deployment strategy.
+  
+  * `.travis.yml` contains a set of [environment variables](https://docs.travis-ci.com/user/environment-variables/) and steps of build process.
+  * `deploy_travis.sh` defines that final python wheels will be deployed to [dist.apache.org/dev](https://dist.apache.org/repos/dist/dev/beam/)
+    using svn with your apache credential.
+  * `config.sh` defines custom build steps.
+
+## User Guide
+
+* Fork this repo into your own github account.
+
+* Sign up [travis](https://travis-ci.com/) with your github account and add this folk beam-wheels repository into travis.
+
+* In travis build console > More options > Settings > Environment Variables:
+
+  * Add `RC` and `VERSION` with 'Display value in build log' enabled (e.g. RC=rc1, RELEASE=2.6.0).
+  * Add `APACHE_USERNAME` and `APACHE_SECRET` with 'Display value in build log' disabled(which encrypt your credential).
+  
+    __NOTE__: If you have special characters in your credential, please escape them following the [guide](https://docs.travis-ci.com/user/encryption-keys/#note-on-escaping-certain-symbols) properly.
+
+* Create and push a new branch(e.g. release_2_6_0) into your folk beam-wheels repository, which will trigger the travis build.
+
+* Confirm that build successful and wheels get staged on dist.apache.org.
+
+* Delete your apache credential in travis environment.

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,13 @@
+# Define custom utilities
+# Test for OSX with [ -n "$IS_OSX" ]
+
+function pre_build {
+    # Any stuff that you need to do before you start building the wheels
+    # Runs in the root directory of this repository.
+    :
+}
+
+function run_tests {
+    # Runs tests on installed distribution from an empty directory
+    python --version
+}

--- a/deploy_travis.sh
+++ b/deploy_travis.sh
@@ -1,0 +1,17 @@
+# Define custom utilities for deploying on travis
+
+function deploy {
+  cd ${TRAVIS_BUILD_DIR}/wheelhouse
+  svn co ${BEAM_SVN_DIR}/${VERSION}
+  for artifact in *.whl; do
+    echo $artifact
+    mv $artifact ${VERSION}/${PYTHON_ARTIFACTS_DIR}/$artifact
+    svn add ${VERSION}/${PYTHON_ARTIFACTS_DIR}/$artifact
+    cd ${VERSION}
+    # Your apache credential is needed here in order to upload artifacts into dist.apache.org
+    # Please add APACHE_USERNAME and APACHE_SECRET in travis build console > More options > Settings > Environment Variables with 'Display value in build log' disabled.
+    # After build finishes, delete your environment variables.
+    svn commit --non-interactive --no-auth-cache --username "$APACHE_USERNAME" --password "$APACHE_SECRET" -m "Upload python wheels"
+    cd ..
+  done
+}


### PR DESCRIPTION
Add there config files to enable python wheels build with travis.

How to trigger travis build from this kind of configurations:
1. Fork from apache/beam-wheels
2. Link this repo into travis-ci
3. Add RC, VERSION as Environment Variables with 'Display value in build log' enabled.
4. Add your apache credential APACHE_USERNAME, APACHE_SECRET with 'Display value in build log' disabled (which will encrypt these 2 values).
5. Trigger the build in travis-ci

r: @aaltay @robertwb 
cc: @pabloem 