### PR TITLE
Enable logging for gcs deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,5 +99,7 @@ deploy:
   skip_cleanup: true
   acl: public-read
   local-dir: wheelhouse
+  edge:
+    branch: master
   on:
     all_branches: true


### PR DESCRIPTION
This will surface any error during GCS upload and fail the test if upload filed.

Example build after this change: (build failed)
https://travis-ci.org/apache/beam-wheels/builds/590549047

Example build before this change: (build silently pass but gcs staging actually failed)
https://travis-ci.org/apache/beam-wheels/builds/590136362

+R: @aaltay @apilloud 