### PR TITLE
update travis config based on https://config.travis-ci.com/explore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python: 3.5
-sudo: required
 dist: trusty
 services: docker
 osx_image: xcode9.4
-
+os: linux
 env:
   global:
       - VERSION=$(echo ${TRAVIS_BRANCH} | sed 's/release-//')
@@ -16,10 +15,7 @@ env:
       - BUILD_DEPENDS="Cython"
       - TEST_DEPENDS=
 
-matrix:
-  exclude:
-    # Exclude the default Python 3.5 build
-    - python: 3.5
+jobs:
   include:
    - os: osx
      language: generic
@@ -96,9 +92,9 @@ deploy:
   access_key_id: ${ACCESS_KEY_ID}
   secret_access_key: ${SECRET_ACCESS_KEY}
   bucket: "beam-wheels-staging"
-  skip_cleanup: true
+  cleanup: true
   acl: public-read
-  local-dir: wheelhouse
+  local_dir: wheelhouse
   edge:
     branch: master
   on:


### PR DESCRIPTION
Travis-ci now has an online tool to validate travis config: https://config.travis-ci.com/explore. 

I updated travis config based on the suggestions from the tool. E.g. fix warnings.