### PR TITLE
Deprecate repository, not used in release process anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
     under the License.
 -->
 
+:no_entry: [DEPRECATED]
+
+This repository is deprecated since python wheels for [Apache Beam](https://github.com/apache/beam) are build with use of GitHub Actions in Apache Beam repository itself.
+
 # Apache Beam Wheels
 
 ## Overview


### PR DESCRIPTION
When GitHub Actions used to build Python Source Distribution and Wheels will be used in release process this repository may be deprecated.

https://github.com/apache/beam/pull/12150